### PR TITLE
Remove the `joinGroup` function in `index.tsx` file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,17 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "plugins": ["unused-imports"],
+  "rules": {
+    "no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "next/core-web-vitals",
   "plugins": ["unused-imports"],
   "rules": {
-    "no-unused-vars": "off", // or "@typescript-eslint/no-unused-vars": "off",
+    "no-unused-vars": "off", 
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "next/core-web-vitals",
   "plugins": ["unused-imports"],
   "rules": {
-    "no-unused-vars": "off", 
+    "no-unused-vars": "off",
     "unused-imports/no-unused-imports": "error",
     "unused-imports/no-unused-vars": [
       "warn",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "typescript": "5.2.2"
   },
   "devDependencies": {
+    "eslint-plugin-unused-imports": "^3.1.0",
     "prettier": "^3.0.3",
     "supabase": "^1.93.0"
   }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import { Identity } from "@semaphore-protocol/identity"
 import { useRouter } from "next/router"
 import React, { useEffect, useState } from "react"
-import { getGroup } from "@/utils/bandadaApi"
 import Stepper from "@/components/stepper"
 import Divider from "@/components/divider"
 
@@ -36,24 +35,6 @@ export default function Home() {
     localStorage.setItem(localStorageTag, identity.toString())
 
     console.log("Your new Semaphore identity was just created 🎉")
-  }
-
-  const joinGroup = async () => {
-    const groupId = process.env.NEXT_PUBLIC_BANDADA_GROUP_ID!
-    const group = await getGroup(groupId)
-
-    if (group === null) {
-      alert("Some error ocurred! Group not found!")
-      return
-    }
-
-    const providerName = group.credentials.id.split("_")[0].toLowerCase()
-
-    const identityCommitment = _identity?.getCommitment().toString()
-
-    window.open(
-      `${process.env.NEXT_PUBLIC_BANDADA_DASHBOARD_URL}/credentials?group=${groupId}&member=${identityCommitment}&provider=${providerName}&redirect_uri=${process.env.NEXT_PUBLIC_APP_URL}`
-    )
   }
 
   const renderIdentity = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,6 +1398,7 @@ __metadata:
     autoprefixer: "npm:10.4.15"
     eslint: "npm:8.48.0"
     eslint-config-next: "npm:13.4.19"
+    eslint-plugin-unused-imports: "npm:^3.1.0"
     ethers: "npm:^6.7.1"
     next: "npm:13.4.19"
     postcss: "npm:8.4.29"
@@ -2301,6 +2302,28 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
   checksum: 10/cb8c5dd5859cace330e24b7d74b9c652c0d93ef1d87957261fe1ac2975c27c918d0d5dc607f25aba4972ce74d04456f4f93883a16ac10cd598680d047fc3495d
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-unused-imports@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "eslint-plugin-unused-imports@npm:3.1.0"
+  dependencies:
+    eslint-rule-composer: "npm:^0.3.0"
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": 6 - 7
+    eslint: 8
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+  checksum: 10/8ad49d6d343492f5a5e6398a57d2c66c28651410d83478b16eac8fadb466cf7785b43cd7cfe33e0fb9624c464c7a92b5b78b34ad2daf418e8ac8fed5c554e1ed
+  languageName: node
+  linkType: hard
+
+"eslint-rule-composer@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "eslint-rule-composer@npm:0.3.0"
+  checksum: 10/c751e71243c6750de553ca0f586a71c7e9d43864bcbd0536639f287332e3f1ed3337bb0db07020652fa90937ceb63b6cc14c0f71fb227e8fc20ca44ee67e837f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR removes the unused `joinGroup` function in the `index.tsx` file. It also adds a new eslint plugin to detect unused code.

Note: This eslint config is temporal, to avoid having unused code. A more complete config for a Nextjs app will be added when issue #11 is solved.

### Related Issue(s)

Closes #7 

Re #11 