### PR TITLE
Use production Bandada urls in development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # This file contains build time variables for dev env.
 
-NEXT_PUBLIC_BANDADA_API_URL=http://localhost:3000
-NEXT_PUBLIC_BANDADA_DASHBOARD_URL=http://localhost:3001
+NEXT_PUBLIC_BANDADA_API_URL=https://api.bandada.pse.dev
+NEXT_PUBLIC_BANDADA_DASHBOARD_URL=https://bandada.pse.dev
 NEXT_PUBLIC_APP_URL=http://localhost:3003


### PR DESCRIPTION
## Description

This PR add the production Bandada urls instead of the local ones to make it easier to work with the boilerplate.

## Issue

Closes #25 