### PR TITLE
Remove NEXT_PUBLIC prefix from sensitive environment variables

### DIFF
--- a/.env.development.local.example
+++ b/.env.development.local.example
@@ -2,6 +2,6 @@
 # Copy these variables with their correct values to a .env.development.local file.
 
 NEXT_PUBLIC_BANDADA_GROUP_ID=<bandada-group-id>
-NEXT_PUBLIC_BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
+BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
 NEXT_PUBLIC_SUPABASE_API_URL=http://localhost:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0

--- a/.env.production.local.example
+++ b/.env.production.local.example
@@ -2,6 +2,6 @@
 # Copy these variables with their correct values to a .env.production.local file.
 
 NEXT_PUBLIC_BANDADA_GROUP_ID=<bandada-group-id>
-NEXT_PUBLIC_BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
+BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
 NEXT_PUBLIC_SUPABASE_API_URL=<supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<supabase-anon-key>

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Update their values:
 ```bash
 # These can be retrieved from the Bandada dashboard (e.g., https://<dashboard_url>/groups/off-chain/<group_id>).
 NEXT_PUBLIC_BANDADA_GROUP_ID=<bandada-group-id>
-NEXT_PUBLIC_BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
+BANDADA_ADMIN_API_KEY=<bandada-admin-api-key>
 
 # If using Supabase online, retrieve from dashboard (Project -> Settings -> API -> URL & Project API keys).
 NEXT_PUBLIC_SUPABASE_API_URL=<supabase-api-url>

--- a/pages/api/join-api-key.ts
+++ b/pages/api/join-api-key.ts
@@ -15,7 +15,7 @@ export default async function handler(
   // Check if the admin API key is defined.
   if (typeof process.env.BANDADA_ADMIN_API_KEY !== "string") {
     throw new Error(
-      "Please, define NEXT_PUBLIC_BANDADA_ADMIN_API_KEY in your .env.development.local or .env.production.local file"
+      "Please, define BANDADA_ADMIN_API_KEY in your .env.development.local or .env.production.local file"
     )
   }
 

--- a/pages/api/join-api-key.ts
+++ b/pages/api/join-api-key.ts
@@ -1,7 +1,7 @@
-import type { NextApiRequest, NextApiResponse } from "next"
 import { addMemberByApiKey, getGroup } from "@/utils/bandadaApi"
 import supabase from "@/utils/supabaseClient"
 import { getRoot } from "@/utils/useSemaphore"
+import type { NextApiRequest, NextApiResponse } from "next"
 
 /**
  * API endpoint to add a member using an API key.
@@ -13,14 +13,14 @@ export default async function handler(
   res: NextApiResponse
 ) {
   // Check if the admin API key is defined.
-  if (typeof process.env.NEXT_PUBLIC_BANDADA_ADMIN_API_KEY !== "string") {
+  if (typeof process.env.BANDADA_ADMIN_API_KEY !== "string") {
     throw new Error(
       "Please, define NEXT_PUBLIC_BANDADA_ADMIN_API_KEY in your .env.development.local or .env.production.local file"
     )
   }
 
   // Retrieve the admin API key.
-  const apiKey = process.env.NEXT_PUBLIC_BANDADA_ADMIN_API_KEY!
+  const apiKey = process.env.BANDADA_ADMIN_API_KEY!
   // Extract groupId and commitment from the request body.
   const { groupId, commitment } = req.body
 


### PR DESCRIPTION
## Changes
- Removed `NEXT_PUBLIC_` prefix from sensitive environment variables in `.env.development.local`
- Updated corresponding environment variable references in the codebase
- Ensures sensitive API keys are only accessible server-side

## Security Impact
This change improves security by preventing sensitive environment variables from being exposed to the client-side browser. Environment variables without the `NEXT_PUBLIC_` prefix are only available on the server side.

## Testing
- Verified that API endpoints continue to function correctly
- Confirmed that sensitive variables are not accessible from the client

## Notes
Please ensure to update your local `.env.development.local` file accordingly.